### PR TITLE
fix(axios): encode user IDs as single URL path segments

### DIFF
--- a/data/javascript/axios/v1-19-0/0_security_blueprint.md
+++ b/data/javascript/axios/v1-19-0/0_security_blueprint.md
@@ -34,7 +34,7 @@ Assign dynamic header values through `AxiosHeaders` or standard request configur
 
 7. **Enforce strict URL formatting and protocol allowlists**
 
-Wrap Axios requests in try-catch blocks to handle `ERR_INVALID_URL` exceptions from malformed inputs, validate complete request destinations against strict application-controlled allowlists, and strip leading slashes from user-supplied path segments to prevent protocol-relative redirection.
+Wrap Axios requests in try-catch blocks to handle `ERR_INVALID_URL` exceptions from malformed inputs and validate complete request destinations against application-controlled allowlists. When interpolating an ID into a fixed route, validate it and encode it as one path segment with `encodeURIComponent()`; reject empty IDs and standalone `.` or `..` segments. Do not treat `baseURL` as a path boundary, and validate redirects and the server's handling of encoded separators separately.
 
 8. **Enforce TLS verification and custom CA configuration**
 

--- a/data/javascript/axios/v1-19-0/1_all_categories.md
+++ b/data/javascript/axios/v1-19-0/1_all_categories.md
@@ -245,28 +245,39 @@ try {
 
 ## Category: input driven boundary selection
 
-### Sanitize URL path segments to prevent protocol-relative request redirection
+### Encode user-controlled IDs as single URL path segments
 
 **Use when**
 
-Building request paths using dynamic user input combined with a `baseURL` in Axios.
+Building a request path from an opaque user ID and an application-controlled `baseURL` and route prefix in Axios.
 
 **Secure rules**
 
-**Rule 1: Strip leading slashes from user-supplied path segments before appending them to base URLs.**
+**Rule 1: Validate the ID and encode it as one path segment before constructing the request URL.**
 
-Prevent protocol-relative URL injection by normalizing dynamic input. If user input contains leading slashes, concatenating it with `baseURL` can alter the target origin and redirect requests to an external server.
+Removing leading slashes does not protect the rest of a URL component: `../admin` can resolve outside `/users/`, `?` starts a query, and `#` truncates what is sent to the server. Encode the original ID with `encodeURIComponent()` instead of deleting characters or accepting it as a URL. This preserves spaces, Unicode, and reserved characters as ID data. Reject empty or non-string values and the standalone IDs `.` and `..`, because URL parsing normalizes those dot segments even when their dots are percent-encoded.
 
 ```javascript
 const api = axios.create({
-  baseURL: 'http://internal.service'
+  baseURL: 'https://api.example.com'
 });
 
 function fetchUserData(userId) {
-  const safePath = String(userId).replace(/^\/+/, '');
-  return api.get(`/users/${safePath}`);
+  if (typeof userId !== 'string' || userId === '' || userId === '.' || userId === '..') {
+    throw new TypeError('userId must be a non-empty string other than . or ..');
+  }
+
+  return api.get(`/users/${encodeURIComponent(userId)}`);
 }
 ```
+
+This example constrains the initial URL Axios constructs. Apply the server's ID contract as well: if its router or proxy treats encoded slashes as separators or decodes more than once, reject those IDs or send them as query data. Validate redirects separately when the destination must remain restricted. `baseURL` and `allowAbsoluteUrls: false` do not constrain relative path traversal.
+
+**Source files**
+
+- [`lib/core/buildFullPath.js`](https://github.com/axios/axios/blob/v1.19.0/lib/core/buildFullPath.js)
+- [`lib/helpers/combineURLs.js`](https://github.com/axios/axios/blob/v1.19.0/lib/helpers/combineURLs.js)
+- [URL Standard: URL path segments](https://url.spec.whatwg.org/#url-path-segment)
 
 
 ## Category: input interpretation safety

--- a/data/javascript/axios/v1-19-0/input-driven-boundary-selection.md
+++ b/data/javascript/axios/v1-19-0/input-driven-boundary-selection.md
@@ -6,25 +6,36 @@ Category: input driven boundary selection
 
 ## input driven boundary selection
 
-### Sanitize URL path segments to prevent protocol-relative request redirection
+### Encode user-controlled IDs as single URL path segments
 
 **Use when**
 
-Building request paths using dynamic user input combined with a `baseURL` in Axios.
+Building a request path from an opaque user ID and an application-controlled `baseURL` and route prefix in Axios.
 
 **Secure rules**
 
-**Rule 1: Strip leading slashes from user-supplied path segments before appending them to base URLs.**
+**Rule 1: Validate the ID and encode it as one path segment before constructing the request URL.**
 
-Prevent protocol-relative URL injection by normalizing dynamic input. If user input contains leading slashes, concatenating it with `baseURL` can alter the target origin and redirect requests to an external server.
+Removing leading slashes does not protect the rest of a URL component: `../admin` can resolve outside `/users/`, `?` starts a query, and `#` truncates what is sent to the server. Encode the original ID with `encodeURIComponent()` instead of deleting characters or accepting it as a URL. This preserves spaces, Unicode, and reserved characters as ID data. Reject empty or non-string values and the standalone IDs `.` and `..`, because URL parsing normalizes those dot segments even when their dots are percent-encoded.
 
 ```javascript
 const api = axios.create({
-  baseURL: 'http://internal.service'
+  baseURL: 'https://api.example.com'
 });
 
 function fetchUserData(userId) {
-  const safePath = String(userId).replace(/^\/+/, '');
-  return api.get(`/users/${safePath}`);
+  if (typeof userId !== 'string' || userId === '' || userId === '.' || userId === '..') {
+    throw new TypeError('userId must be a non-empty string other than . or ..');
+  }
+
+  return api.get(`/users/${encodeURIComponent(userId)}`);
 }
 ```
+
+This example constrains the initial URL Axios constructs. Apply the server's ID contract as well: if its router or proxy treats encoded slashes as separators or decodes more than once, reject those IDs or send them as query data. Validate redirects separately when the destination must remain restricted. `baseURL` and `allowAbsoluteUrls: false` do not constrain relative path traversal.
+
+**Source files**
+
+- [`lib/core/buildFullPath.js`](https://github.com/axios/axios/blob/v1.19.0/lib/core/buildFullPath.js)
+- [`lib/helpers/combineURLs.js`](https://github.com/axios/axios/blob/v1.19.0/lib/helpers/combineURLs.js)
+- [URL Standard: URL path segments](https://url.spec.whatwg.org/#url-path-segment)

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
       "devDependencies": {
         "@astrojs/check": "^0.9.9",
         "@types/node": "^26.1.1",
+        "axios": "1.19.0",
         "markdownlint-cli2": "^0.23.2",
         "typescript": "^6.0.3",
         "wrangler": "^4.114.0"
@@ -2498,6 +2499,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
       "version": "8.20.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.20.0.tgz",
@@ -2715,6 +2729,26 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/axios": {
+      "version": "1.19.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.19.0.tgz",
+      "integrity": "sha512-ht/iuYZXEjFxLH/Hkezgd7m6JKlHHXEUSneaDz8uZe1Gj5QZtCnpyDsckvAiEnT89OEbCLmnte4R4sn7P0EKFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.6",
+        "https-proxy-agent": "^5.0.1",
+        "proxy-from-env": "^2.1.0"
+      }
+    },
     "node_modules/axobject-query": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-4.1.0.tgz",
@@ -2778,6 +2812,20 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/call-bind-apply-helpers": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
+      "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/ccount": {
@@ -2906,6 +2954,19 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/comma-separated-tokens": {
       "version": "2.0.3",
@@ -3088,6 +3149,16 @@
       "integrity": "sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==",
       "license": "MIT"
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/dequal": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
@@ -3213,6 +3284,21 @@
         "node": ">=4"
       }
     },
+    "node_modules/dunder-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
+      "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "gopd": "^1.2.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/emmet": {
       "version": "2.4.11",
       "resolved": "https://registry.npmjs.org/emmet/-/emmet-2.4.11.tgz",
@@ -3259,11 +3345,60 @@
         "url": "https://github.com/sponsors/antfu"
       }
     },
+    "node_modules/es-define-property": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
+      "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-errors": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
+      "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/es-module-lexer": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.3.1.tgz",
       "integrity": "sha512-shc1dbU90Yl/xq1QrC7QRtfcwURZuVRfPhZbDoldJ1cn1gzDvBaBWlv0eFolj5+0znnPJz5TXLxsN77X/12KTA==",
       "license": "MIT"
+    },
+    "node_modules/es-object-atoms": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/esbuild": {
       "version": "0.28.1",
@@ -3454,6 +3589,27 @@
         "node": ">=8"
       }
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fontace": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/fontace/-/fontace-0.4.1.tgz",
@@ -3475,6 +3631,23 @@
         "node": ">=20"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.6.tgz",
+      "integrity": "sha512-vKatAh4SlVfgbv+YtmhiRjhEMJsYpsG1Y2rMQtR+SVSbytsSD1YGzDIcrAJmdFec88u/+VoGmxnl+80gL1tRCQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.4",
+        "mime-types": "^2.1.35"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/fsevents": {
       "version": "2.3.3",
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
@@ -3487,6 +3660,16 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/function-bind": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
+      "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
       }
     },
     "node_modules/get-caller-file": {
@@ -3510,6 +3693,45 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/get-intrinsic": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
+      "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "call-bind-apply-helpers": "^1.0.2",
+        "es-define-property": "^1.0.1",
+        "es-errors": "^1.3.0",
+        "es-object-atoms": "^1.1.1",
+        "function-bind": "^1.1.2",
+        "get-proto": "^1.0.1",
+        "gopd": "^1.2.0",
+        "has-symbols": "^1.1.0",
+        "hasown": "^2.0.2",
+        "math-intrinsics": "^1.1.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/get-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
+      "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "dunder-proto": "^1.0.1",
+        "es-object-atoms": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/get-tsconfig": {
@@ -3567,6 +3789,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/gopd": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
+      "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/h3": {
       "version": "1.15.11",
       "resolved": "https://registry.npmjs.org/h3/-/h3-1.15.11.tgz",
@@ -3582,6 +3817,48 @@
         "radix3": "^1.1.2",
         "ufo": "^1.6.3",
         "uncrypto": "^0.1.3"
+      }
+    },
+    "node_modules/has-symbols": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
+      "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/hasown": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "function-bind": "^1.1.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/hast-util-from-html": {
@@ -3709,6 +3986,20 @@
       "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.2.0.tgz",
       "integrity": "sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==",
       "license": "BSD-2-Clause"
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/ignore": {
       "version": "7.0.6",
@@ -4400,6 +4691,16 @@
         "url": "https://github.com/chalk/strip-ansi?sponsor=1"
       }
     },
+    "node_modules/math-intrinsics": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
+      "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "13.2.1",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
@@ -5000,6 +5301,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/miniflare": {
@@ -5977,6 +6301,16 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode.js": {

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   "devDependencies": {
     "@astrojs/check": "^0.9.9",
     "@types/node": "^26.1.1",
+    "axios": "1.19.0",
     "markdownlint-cli2": "^0.23.2",
     "typescript": "^6.0.3",
     "wrangler": "^4.114.0"

--- a/skills/securitycards/references/catalog.json
+++ b/skills/securitycards/references/catalog.json
@@ -3438,7 +3438,7 @@
                 {
                   "slug": "input-driven-boundary-selection",
                   "title": "Input Driven Boundary Selection",
-                  "description": "Building request paths using dynamic user input combined with a `baseURL` in Axios.",
+                  "description": "Building a request path from an opaque user ID and an application-controlled `baseURL` and route prefix in Axios.",
                   "canonicalUrl": "https://securitycards.rewarelabs.com/downloads/javascript/axios/v1-19-0/input-driven-boundary-selection.md",
                   "path": "/downloads/javascript/axios/v1-19-0/input-driven-boundary-selection.md"
                 },

--- a/tests/axios-path-segments.test.mjs
+++ b/tests/axios-path-segments.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { once } from 'node:events';
+import { readFile } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import { after, before, test } from 'node:test';
+import { runInNewContext } from 'node:vm';
+import axios from 'axios';
+
+const cardUrl = new URL(
+  '../data/javascript/axios/v1-19-0/input-driven-boundary-selection.md',
+  import.meta.url,
+);
+const card = await readFile(cardUrl, 'utf8');
+const snippets = [...card.matchAll(/^```javascript\n([\s\S]*?)^```$/gm)];
+assert.equal(snippets.length, 1, 'The path-segment card must provide one runnable example');
+assert.equal(axios.VERSION, '1.19.0', 'Run the example against its documented Axios version');
+
+// Execute the published example rather than maintaining a test-only copy.
+const { api, fetchUserData } = runInNewContext(
+  `${snippets[0][1]}\n;({ api, fetchUserData });`,
+  { axios },
+  { filename: cardUrl.pathname },
+);
+
+let requestCount = 0;
+const server = createServer((request, response) => {
+  requestCount += 1;
+  response.writeHead(200, { 'content-type': 'application/json' });
+  response.end(JSON.stringify({ url: request.url, host: request.headers.host }));
+});
+
+before(async () => {
+  server.listen(0, '127.0.0.1');
+  await once(server, 'listening');
+  api.defaults.baseURL = `http://127.0.0.1:${server.address().port}`;
+  api.defaults.adapter = 'http';
+  api.defaults.proxy = false;
+  api.defaults.timeout = 1000;
+});
+
+after(() => new Promise((resolve, reject) => {
+  server.close(error => error ? reject(error) : resolve());
+}));
+
+test('preserves ordinary identifiers in the requested user endpoint', async () => {
+  for (const [id, path] of [
+    ['alice', '/users/alice'],
+    ['alice.smith-42', '/users/alice.smith-42'],
+    ['Alice Smith', '/users/Alice%20Smith'],
+    ['用户', '/users/%E7%94%A8%E6%88%B7'],
+  ]) {
+    const { data } = await fetchUserData(id);
+    assert.equal(data.url, path, id);
+    assert.equal(data.host, new URL(api.defaults.baseURL).host);
+  }
+});
+
+test('keeps URL delimiters and percent escapes inside one user ID', async () => {
+  for (const [id, path] of [
+    ['alice?role=admin', '/users/alice%3Frole%3Dadmin'],
+    ['alice#details', '/users/alice%23details'],
+    ['/alice', '/users/%2Falice'],
+    ['//other.example/alice', '/users/%2F%2Fother.example%2Falice'],
+    ['alice/bob', '/users/alice%2Fbob'],
+    ['alice\\bob', '/users/alice%5Cbob'],
+    ['%2e%2e', '/users/%252e%252e'],
+    ['100%', '/users/100%25'],
+  ]) {
+    const { data } = await fetchUserData(id);
+    assert.equal(data.url, path, id);
+    assert.equal(data.host, new URL(api.defaults.baseURL).host);
+  }
+});
+
+test('does not resolve traversal-shaped identifiers outside the user endpoint', async () => {
+  for (const [id, path] of [
+    ['../admin', '/users/..%2Fadmin'],
+    ['..\\admin', '/users/..%5Cadmin'],
+    ['%2e%2e/admin', '/users/%252e%252e%2Fadmin'],
+  ]) {
+    const { data } = await fetchUserData(id);
+    assert.equal(data.url, path, id);
+  }
+});
+
+test('rejects empty, non-string and standalone dot-segment IDs before HTTP', async () => {
+  const requestsBefore = requestCount;
+  for (const id of ['', '.', '..', null, undefined, 42, {}, []]) {
+    await assert.rejects(async () => fetchUserData(id), { name: 'TypeError' });
+  }
+  assert.equal(requestCount, requestsBefore);
+});


### PR DESCRIPTION
The Axios v1.19.0 path-segment example strips leading slashes but still sends `../admin` to `/admin` and lets `alice?role=admin` add a query parameter. It also changes the identifier `/alice` to `alice`.

Encode each original string ID as one path segment and reject empty values and standalone `.`/`..` segments. Keep the category, combined download, blueprint, and generated skill catalog consistent. The card states the boundary explicitly: this protects the initial URL construction; server decoding behavior and redirects still need their own validation.

The regression test executes the published Markdown example with Axios pinned to 1.19.0 and checks actual requests to a loopback HTTP server. It covers ordinary and Unicode IDs, reserved characters, percent escapes, traversal-shaped IDs, and rejection before any HTTP request. The ordinary-ID test passes on the original example; the other three tests fail on the original behavior.

Validation on Node.js 22.16.0:

- `node --test tests/axios-path-segments.test.mjs`: 4 passing tests.
- `ASTRO_TELEMETRY_DISABLED=1 npm run validate`: card/Markdown lint, Astro checks, all 12 tests, and production build/artifact verification passed. Refreshed the generated skill catalog, then reran `npm run validate:skill` successfully.
- Checked the rendered Axios page and category, library, and JavaScript downloads; existing locked dependency versions are unchanged.

The build retains its existing Shiki diagnostics about `conf` highlighting and multiple highlighter instances.
